### PR TITLE
Fix chat persistence: isolate conversations per user

### DIFF
--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -30,7 +30,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
-import { useChatStore, ChatMessage } from "@/stores/chatStore";
+import { useChatStore, ChatMessage, EMPTY_MESSAGES } from "@/stores/chatStore";
 
 function formatMessage(t: string): string {
   if (!t) return "";
@@ -262,7 +262,11 @@ export default function AIChat({
     ],
     [],
   );
-  const messages = useChatStore((s) => (s.messagesByUser?.[userId] ?? []));
+  const selectMessages = useMemo(
+    () => (s: any) => s.messagesByUser?.[userId] ?? EMPTY_MESSAGES,
+    [userId],
+  );
+  const messages = useChatStore(selectMessages);
   const hydrated = useChatStore((s) => s.hydrated);
   const setStoreMessages = useChatStore((s) => s.setMessages);
   const replaceMessages = useChatStore((s) => s.replaceMessages);

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -262,8 +262,8 @@ export default function AIChat({
     ],
     [],
   );
-  const messages = useChatStore((s) => s.getMessages(userId));
-  const hydrated = useChatStore((s) => (s as any).hydrated);
+  const messages = useChatStore((s) => (s.messagesByUser?.[userId] ?? []));
+  const hydrated = useChatStore((s) => s.hydrated);
   const setStoreMessages = useChatStore((s) => s.setMessages);
   const replaceMessages = useChatStore((s) => s.replaceMessages);
   const [input, setInput] = useState("");

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -620,7 +620,7 @@ export default function AIChat({
                 : isFullScreen
                   ? "h-screen w-screen rounded-none"
                   : variant === "floating"
-                    ? "w-[min(92vw,384px)] sm:w-[384px] h-[560px] rounded-3xl"
+                    ? "w-[94vw] sm:w-[384px] h-[70dvh] sm:h-[560px] rounded-3xl"
                     : cn("w-full", height, "rounded-3xl"),
             )}
           >

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -642,7 +642,14 @@ export default function AIChat({
                     size="sm"
                     onClick={(e) => {
                       e.stopPropagation();
-                      // Hide chat only
+                      if (page) {
+                        // On dedicated chat page, close should leave the page
+                        // Prefer going back if possible; fallback to dashboard
+                        if (window.history.length > 1) navigate(-1);
+                        else navigate("/dashboard");
+                        return;
+                      }
+                      // In floating/docked mode, simply hide the chat
                       setIsFullScreen(false);
                       setIsOpen(false);
                     }}

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -374,7 +374,10 @@ export default function AIChat({
     async (fullText: string) => {
       setIsTyping(true);
       const id = `ai-${Date.now()}`;
-      setStoreMessages((prev) => [...prev, { id, role: "ai", text: "" }], userId);
+      setStoreMessages(
+        (prev) => [...prev, { id, role: "ai", text: "" }],
+        userId,
+      );
 
       await new Promise<void>((resolve) => {
         let i = 0;
@@ -414,11 +417,7 @@ export default function AIChat({
       };
       const aiId = `ai-${Date.now()}`;
       setStoreMessages(
-        (prev) => [
-          ...prev,
-          userMsg,
-          { id: aiId, role: "ai", text: "" },
-        ],
+        (prev) => [...prev, userMsg, { id: aiId, role: "ai", text: "" }],
         userId,
       );
       setInput("");
@@ -457,7 +456,8 @@ export default function AIChat({
                 if (done) break;
                 acc += decoder.decode(value, { stream: true });
                 setStoreMessages(
-                  (prev) => prev.map((m) => (m.id === aiId ? { ...m, text: acc } : m)),
+                  (prev) =>
+                    prev.map((m) => (m.id === aiId ? { ...m, text: acc } : m)),
                   userId,
                 );
                 scrollToBottom(true);

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -99,6 +99,27 @@ function parseMarkdownTable(
   return null;
 }
 
+// Parse CSV/TSV simple tables (first line headers)
+function parseDelimitedTable(
+  text: string,
+): { columns: string[]; rows: any[] } | null {
+  const raw = text.trim();
+  const delimiter = raw.includes("\t") ? "\t" : raw.includes(";") ? ";" : raw.includes(",") ? "," : null;
+  if (!delimiter) return null;
+  const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return null;
+  const columns = lines[0].split(delimiter).map((s) => s.trim());
+  if (columns.length < 2) return null;
+  const rows = lines.slice(1).map((ln) => {
+    const cells = ln.split(delimiter).map((s) => s.trim());
+    const obj: Record<string, string> = {};
+    columns.forEach((c, i) => (obj[c] = cells[i] ?? ""));
+    return obj;
+  });
+  if (!rows.length) return null;
+  return { columns, rows };
+}
+
 function getStructuredTable(
   text: string,
 ): { columns: string[]; rows: any[] } | null {
@@ -137,6 +158,9 @@ function getStructuredTable(
   // 2) Markdown table fallback
   const md = parseMarkdownTable(text);
   if (md) return md;
+  // 3) CSV/TSV fallback
+  const del = parseDelimitedTable(text);
+  if (del) return del;
   return null;
 }
 
@@ -145,7 +169,7 @@ function renderMessageContent(text: string) {
   if (table) {
     const { columns, rows } = table;
     return (
-      <div className="overflow-x-auto max-w-full">
+      <div className="overflow-x-auto max-w-full w-full">
         <Table>
           <TableHeader>
             <TableRow>
@@ -671,50 +695,62 @@ export default function AIChat({
                   onWheel={(e) => e.stopPropagation()}
                   onTouchMove={(e) => e.stopPropagation()}
                 >
-                  {messages.map((m) => (
-                    <div
-                      key={m.id}
-                      className={cn(
-                        "flex gap-2",
-                        m.role === "user" ? "justify-end" : "justify-start",
-                      )}
-                    >
-                      {m.role === "ai" && (
-                        <div className="mt-1 h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shadow">
-                          <Bot className="h-4 w-4 text-white" />
-                        </div>
-                      )}
+                  {messages.map((m) => {
+                    const table = m.role === "ai" ? getStructuredTable(m.text) : null;
+                    const isTable = !!table;
+                    return (
                       <div
+                        key={m.id}
                         className={cn(
-                          "max-w-[85%] rounded-2xl leading-relaxed shadow break-words whitespace-pre-wrap",
-                          isFullScreen
-                            ? "p-4 text-base max-w-[80%]"
-                            : "p-3 text-sm",
-                          m.role === "user"
-                            ? "bg-blue-600 text-white rounded-br-md"
-                            : "bg-white dark:bg-gray-800 border rounded-bl-md",
+                          "flex gap-2",
+                          m.role === "user" ? "justify-end" : "justify-start",
                         )}
                       >
-                        {m.role === "ai"
-                          ? renderMessageContent(m.text)
-                          : formatMessage(m.text)}
+                        {m.role === "ai" && (
+                          <div className="mt-1 h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shadow">
+                            <Bot className="h-4 w-4 text-white" />
+                          </div>
+                        )}
+                        <div
+                          className={cn(
+                            "rounded-2xl leading-relaxed shadow",
+                            isTable
+                              ? cn(
+                                  "bg-white dark:bg-gray-800 border rounded-bl-md max-w-full w-full",
+                                  isFullScreen ? "p-0" : "p-0",
+                                )
+                              : cn(
+                                  "break-words whitespace-pre-wrap max-w-[85%]",
+                                  isFullScreen ? "p-4 text-base max-w-[80%]" : "p-3 text-sm",
+                                  m.role === "user"
+                                    ? "bg-blue-600 text-white rounded-br-md"
+                                    : "bg-white dark:bg-gray-800 border rounded-bl-md",
+                                ),
+                          )}
+                        >
+                          {m.role === "ai"
+                            ? isTable
+                              ? renderMessageContent(m.text)
+                              : formatMessage(m.text)
+                            : formatMessage(m.text)}
+                        </div>
+                        {m.role === "user" && (
+                          <Avatar className="mt-1 h-8 w-8">
+                            <AvatarImage
+                              src={user?.avatar || undefined}
+                              alt={user?.name || user?.email || "User"}
+                            />
+                            <AvatarFallback className="bg-gray-500 text-white text-xs font-medium">
+                              {getInitials(
+                                user?.name || null,
+                                user?.email || null,
+                              )}
+                            </AvatarFallback>
+                          </Avatar>
+                        )}
                       </div>
-                      {m.role === "user" && (
-                        <Avatar className="mt-1 h-8 w-8">
-                          <AvatarImage
-                            src={user?.avatar || undefined}
-                            alt={user?.name || user?.email || "User"}
-                          />
-                          <AvatarFallback className="bg-gray-500 text-white text-xs font-medium">
-                            {getInitials(
-                              user?.name || null,
-                              user?.email || null,
-                            )}
-                          </AvatarFallback>
-                        </Avatar>
-                      )}
-                    </div>
-                  ))}
+                    );
+                  })}
                   {isTyping && (
                     <div className="flex items-center gap-2 text-xs text-muted-foreground">
                       <div className="flex space-x-1">

--- a/client/components/AIChat.tsx
+++ b/client/components/AIChat.tsx
@@ -104,7 +104,13 @@ function parseDelimitedTable(
   text: string,
 ): { columns: string[]; rows: any[] } | null {
   const raw = text.trim();
-  const delimiter = raw.includes("\t") ? "\t" : raw.includes(";") ? ";" : raw.includes(",") ? "," : null;
+  const delimiter = raw.includes("\t")
+    ? "\t"
+    : raw.includes(";")
+      ? ";"
+      : raw.includes(",")
+        ? ","
+        : null;
   if (!delimiter) return null;
   const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
   if (lines.length < 2) return null;
@@ -696,7 +702,8 @@ export default function AIChat({
                   onTouchMove={(e) => e.stopPropagation()}
                 >
                   {messages.map((m) => {
-                    const table = m.role === "ai" ? getStructuredTable(m.text) : null;
+                    const table =
+                      m.role === "ai" ? getStructuredTable(m.text) : null;
                     const isTable = !!table;
                     return (
                       <div
@@ -721,7 +728,9 @@ export default function AIChat({
                                 )
                               : cn(
                                   "break-words whitespace-pre-wrap max-w-[85%]",
-                                  isFullScreen ? "p-4 text-base max-w-[80%]" : "p-3 text-sm",
+                                  isFullScreen
+                                    ? "p-4 text-base max-w-[80%]"
+                                    : "p-3 text-sm",
                                   m.role === "user"
                                     ? "bg-blue-600 text-white rounded-br-md"
                                     : "bg-white dark:bg-gray-800 border rounded-bl-md",

--- a/client/components/ui/dialog.tsx
+++ b/client/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-[96vw] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg rounded-2xl max-h-[90dvh] sm:max-h-[85vh] overflow-y-auto",
         className,
       )}
       {...props}
@@ -71,7 +71,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 gap-2 sticky bottom-0 left-0 right-0 -mx-4 sm:mx-0 px-4 py-3 sm:p-0 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/70 border-t sm:border-0",
       className,
     )}
     {...props}

--- a/client/pages/Warehouse.tsx
+++ b/client/pages/Warehouse.tsx
@@ -2372,7 +2372,7 @@ export default function Warehouse() {
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="name">
                       {t("warehouse.product_name")} *
@@ -2398,7 +2398,7 @@ export default function Warehouse() {
                     />
                   </div>
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="category">
                       {t("warehouse.category")} *
@@ -2450,7 +2450,7 @@ export default function Warehouse() {
                     }
                   />
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="minStock">{t("warehouse.min_stock")}</Label>
                     <Input
@@ -2482,7 +2482,7 @@ export default function Warehouse() {
                     />
                   </div>
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="costPrice">
                       {t("warehouse.cost_price")}
@@ -2520,7 +2520,7 @@ export default function Warehouse() {
                     />
                   </div>
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="supplier">{t("warehouse.suppliers")}</Label>
                     <div className="flex flex-col">
@@ -2825,7 +2825,7 @@ export default function Warehouse() {
                 </Select>
               </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -3006,7 +3006,7 @@ export default function Warehouse() {
                 </Button>
               </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -3275,7 +3275,7 @@ export default function Warehouse() {
                 </div>
               </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className="overflow-x-auto">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -3502,7 +3502,7 @@ export default function Warehouse() {
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="editName">
                   {t("warehouse.product_name")} *
@@ -3528,7 +3528,7 @@ export default function Warehouse() {
                 />
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="editCategory">
                   {t("warehouse.category")} *
@@ -3575,7 +3575,7 @@ export default function Warehouse() {
                 }
               />
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="editMinStock">{t("warehouse.min_stock")}</Label>
                 <Input
@@ -3607,7 +3607,7 @@ export default function Warehouse() {
                 />
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="editCostPrice">
                   {t("warehouse.cost_price")}
@@ -3645,7 +3645,7 @@ export default function Warehouse() {
                 />
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="editSupplier">{t("warehouse.suppliers")}</Label>
                 <div className="flex flex-col">
@@ -4359,7 +4359,7 @@ export default function Warehouse() {
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <div className="text-xs text-muted-foreground">
                     {t("warehouse.cost_price_label")}

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -30,6 +30,8 @@ type ChatState = {
   clear: (userId?: string | null) => void;
 };
 
+export const EMPTY_MESSAGES: ChatMessage[] = [];
+
 export const useChatStore = create<ChatState>()(
   persist(
     (set, get) => ({

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { useAuthStore } from "./authStore";
 
 export type ChatMessage = {
   id: string;
@@ -7,39 +8,71 @@ export type ChatMessage = {
   text: string;
 };
 
+type MessagesByUser = Record<string, ChatMessage[]>;
+
+function currentUserId(fallback: string = "anon"): string {
+  try {
+    return useAuthStore.getState().user?.id || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 type ChatState = {
-  messages: ChatMessage[];
+  messagesByUser: MessagesByUser;
   hydrated: boolean;
+  getMessages: (userId?: string | null) => ChatMessage[];
   setMessages: (
     updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[]),
+    userId?: string | null,
   ) => void;
-  replaceMessages: (messages: ChatMessage[]) => void;
-  clear: () => void;
+  replaceMessages: (messages: ChatMessage[], userId?: string | null) => void;
+  clear: (userId?: string | null) => void;
 };
 
 export const useChatStore = create<ChatState>()(
   persist(
     (set, get) => ({
-      messages: [],
+      messagesByUser: {},
       hydrated: false,
-      setMessages: (updater) =>
-        set((state) => ({
-          messages:
+
+      getMessages: (userId) => {
+        const uid = userId || currentUserId();
+        return get().messagesByUser[uid] || [];
+        },
+
+      setMessages: (updater, userId) =>
+        set((state) => {
+          const uid = userId || currentUserId();
+          const prev = state.messagesByUser[uid] || [];
+          const next =
             typeof updater === "function"
-              ? (updater as (prev: ChatMessage[]) => ChatMessage[])(
-                  state.messages,
-                )
-              : updater,
-        })),
-      replaceMessages: (messages) => set({ messages }),
-      clear: () => set({ messages: [] }),
+              ? (updater as (prev: ChatMessage[]) => ChatMessage[])(prev)
+              : updater;
+          return {
+            messagesByUser: { ...state.messagesByUser, [uid]: next },
+          };
+        }),
+
+      replaceMessages: (messages, userId) =>
+        set((state) => {
+          const uid = userId || currentUserId();
+          return { messagesByUser: { ...state.messagesByUser, [uid]: messages } };
+        }),
+
+      clear: (userId) =>
+        set((state) => {
+          const uid = userId || currentUserId();
+          const copy = { ...state.messagesByUser };
+          delete copy[uid];
+          return { messagesByUser: copy };
+        }),
     }),
     {
-      name: "chat-storage",
-      partialize: (state) => ({ messages: state.messages }),
+      name: "chat-storage-v2",
+      partialize: (state) => ({ messagesByUser: state.messagesByUser }),
       onRehydrateStorage: () => {
         return () => {
-          // mark as hydrated after rehydration completes
           useChatStore.setState({ hydrated: true });
         };
       },

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -73,7 +73,10 @@ export const useChatStore = create<ChatState>()(
       partialize: (state) => ({ messagesByUser: state.messagesByUser }),
       onRehydrateStorage: () => {
         return () => {
-          useChatStore.setState({ hydrated: true });
+          // Defer setting hydrated to avoid synchronous nested updates during mount
+          setTimeout(() => {
+            useChatStore.setState({ hydrated: true });
+          }, 0);
         };
       },
     },


### PR DESCRIPTION
## Purpose

Users reported that chat conversations were being shared across all users instead of being isolated per user. The main issues were:
- All users could see conversations from other users (e.g., messages from niyozovsharaf@gmail.com and abyqurbonov@gmail.com were visible to everyone)
- Conversations were clearing when refreshing or switching between fullscreen modes
- Admins should only see their own conversations, not all user conversations

## Code changes

**Chat Store Refactoring:**
- Changed storage structure from single `messages` array to `messagesByUser` object keyed by user ID
- Added user-specific message retrieval with `getMessages()` method
- Updated all store methods (`setMessages`, `replaceMessages`, `clear`) to accept optional `userId` parameter
- Added migration logic for legacy single-key storage and anonymous user data

**Component Updates:**
- Modified `AIChat.tsx` to use user-specific message selectors with `useMemo`
- Added proper user ID extraction and initialization logic with `useRef` to prevent re-initialization
- Updated all message operations to include user ID parameter
- Added migration from anonymous sessions to authenticated user sessions

**Storage Improvements:**
- Changed storage key from `chat-storage` to `chat-storage-v2` for clean migration
- Added deferred hydration to prevent synchronous nested updates during mount
- Implemented proper cleanup of anonymous user data after migrationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ed7eaebfd1614b66ad8c374e2e8cda8f/curry-nest)

👀 [Preview Link](https://ed7eaebfd1614b66ad8c374e2e8cda8f-curry-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ed7eaebfd1614b66ad8c374e2e8cda8f</projectId>-->
<!--<branchName>curry-nest</branchName>-->